### PR TITLE
Removed .text from python package example as it throws an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ python airscraper/airscraper.py [url] > [filename].csv
 from airscraper import AirScraper
 
 client = AirScraper([url])
-data = client.get_table().text
+data = client.get_table()
 
 # print the result
 print(data)


### PR DESCRIPTION
Was trying to use the example code and received an error with .text. Removing it resolved the error.